### PR TITLE
9 Campos vacíos en tabla de clientes cuando faltan datos, sin mostrar username o email del usuario asociado.

### DIFF
--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -53,7 +53,7 @@ class Customer extends Model
     final public function getFirstName(): string
     {
         return is_null($this->first_name)
-            ? 'No tiene datos'
+            ? $this->user->getName()
             : ucfirst($this->first_name);
     }
 


### PR DESCRIPTION
Modifica la lógica para obtener el nombre del cliente.

Ahora, si el nombre del cliente no está definido, se obtiene
el nombre del usuario asociado, asegurando que siempre se
muestre un nombre válido.

FIXES #9
