### PR TITLE
11 Eliminar atributte de los modelos

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -18,28 +18,28 @@ class Company extends Model
 
     public function getId()
     {
-        return $this->attributes['id'];
+        return $this->id;
     }
 
     public function getName()
     {
-        return $this->attributes['name'];
+        return $this->name;
     }
 
     public function getDescription()
     {
-        return $this->attributes['description'];
+        return $this->description;
     }
 
     public function setName($name)
     {
-        $this->attributes['name'] = $name;
+        $this->name = $name;
         return $this;
     }
 
     public function setDescription($description)
     {
-        $this->attributes['description'] = $description;
+        $this->description = $description;
         return $this;
     }
 

--- a/app/Models/CompanyProduct.php
+++ b/app/Models/CompanyProduct.php
@@ -29,22 +29,22 @@ class CompanyProduct extends Pivot
 
     public function getId()
     {
-        return $this->attributes['id'];
+        return $this->id;
     }
 
     public function getCompanyId()
     {
-        return $this->attributes['company_id'];
+        return $this->company_id;
     }
 
     public function getProductId()
     {
-        return $this->attributes['product_id'];
+        return $this->product_id;
     }
 
     public function getPrice()
     {
-        return $this->attributes['price'];
+        return $this->price;
     }
 
     public function company(): BelongsTo

--- a/app/Models/Log.php
+++ b/app/Models/Log.php
@@ -23,63 +23,62 @@ class Log extends Model
 
     function getId()
     {
-        return $this->attributes['id'];
+        return $this->id;
     }
     function getAction()
     {
-        return $this->attributes['action'];
+        return $this->action;
     }
     function getDetail()
     {
-        return $this->attributes['detail'];
+        return $this->detail;
     }
     function getIp()
     {
-        return $this->attributes['ip'];
+        return $this->ip;
     }
     function getObjeto()
     {
-        return $this->attributes['objeto'];
+        return $this->objeto;
     }
     function getObjetoId()
     {
-        return $this->attributes['objeto_id'];
+        return $this->objeto_id;
     }
 
     function getUserId()
     {
-        return $this->attributes['user_id'];
+        return $this->user_id;
     }
-
 
     function setAction($action)
     {
-        $this->attributes['action'] = $action;
+        $this->action = $action;
         return $this;
 
     }
     function setDetail($detail)
     {
-        $this->attributes['detail'] = $detail;
+        $this->detail = $detail;
         return $this;
     }
     function setIp($ip)
     {
-        $this->attributes['ip'] = $ip;
+        $this->ip = $ip;
         return $this;
     }
     function setUserId($id)
     {
-        $this->attributes['user_id'] = $id;
+        $this->user_id = $id;
     }
     function setObjeto($objeto)
     {
-        $this->attributes['objeto'] = $objeto;
+        $this->objeto = $objeto;
         return $this;
     }
     function setObjetoId($id)
     {
-        $this->attributes['objeto_id'] = $id;
+        $this->objeto_id = $id;
         return $this;
     }
 

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -21,49 +21,49 @@ class Note extends Model
 
     public function getId()
     {
-        return $this->attributes['id'];
+        return $this->id;
     }
 
     public function getTitle()
     {
-        return $this->attributes['title'];
+        return $this->title;
     }
 
     public function getContents()
     {
-        return $this->attributes['contents'];
+        return $this->contents;
     }
 
     public function getCompleted()
     {
-        return $this->attributes['completed'];
+        return $this->completed;
     }
 
     public function setTitle($title)
     {
-        $this->attributes['title'] = $title;
+        $this->title = $title;
         return $this;
     }
 
     public function setContents($contents)
     {
-        $this->attributes['contents'] = $contents;
+        $this->contents = $contents;
         return $this;
     }
 
     public function setCompleted($completed)
     {
-        $this->attributes['completed'] = $completed;
+        $this->completed = $completed;
     }
 
     public function isCompleted()
     {
-        $this->attributes['completed'] = true;
+        $this->completed = true;
     }
 
     public function isNotCompleted()
     {
-        $this->attributes['completed'] = false;
+        $this->completed = false;
     }
 
     public function getFormattedBirthDateAttribute()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,50 +26,50 @@ class User extends Authenticatable
 
     function getId()
     {
-        return $this->attributes['id'];
+        return $this->id;
     }
 
     function getName()
     {
-        return $this->attributes['name'];
+        return $this->name;
     }
 
     function getEmail()
     {
-        return $this->attributes['email'];
+        return $this->email;
     }
 
     function getPassword()
     {
-        return $this->attributes['password'];
+        return $this->password;
     }
 
     function getIsConnected()
     {
-        return $this->attributes['is_connected'];
+        return $this->is_connected;
     }
 
     function setName($name)
     {
-        $this->attributes['name'] = $name;
+        $this->name = $name;
         return $this;
     }
 
     function setEmail($email)
     {
-        $this->attributes['email'] = $email;
+        $this->email = $email;
         return $this;
     }
 
     function setPassword($password)
     {
-        $this->attributes['password'] = $password;
+        $this->password = $password;
         return $this;
     }
 
     function setIsConnected($is_connected)
     {
-        $this->attributes['is_connected'] = $is_connected;
+        $this->is_connected = $is_connected;
         return $this;
     }
 


### PR DESCRIPTION
Refactoriza los métodos getter y setter en los modelos
(Company, CompanyProduct, Log, Note, User) para acceder
directamente a los atributos en lugar de usar
$this->attributes['attribute'].

Este cambio mejora la legibilidad y concisión del código
al simplificar la forma en que se interactúa con los
atributos de los modelos, haciendo el código más fácil de
mantener y entender.
