### PR TITLE
17 Eliminar Funciones

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -97,7 +97,7 @@ class AuthController extends Controller
         $user->save();
 
         $customer = new Customer();
-        $customer->setUserId($user->id);   // asociación 1–1 con el usuario
+        $customer->user_id = $user->id;   // asociación 1–1 con el usuario
         $customer->save();
 
         // Crea una nueva instancia de registro de inicio de sesión

--- a/app/Http/Controllers/CustomerController.php
+++ b/app/Http/Controllers/CustomerController.php
@@ -185,8 +185,8 @@ class CustomerController extends Controller
         $log->objeto = 'customers';
         $log->objeto_id = $id;
         $log->detail = $customer->toJson();
-        $log->setIp('1111');
-        $log->setUserId(auth()->user()->id);
+        $log->ip = '1111';
+        $log->user_id =auth()->user()->id;
         $log->save();
 
         $customer->delete();

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -182,12 +182,12 @@ class ProductController extends Controller
 
         // Registro de la eliminación en el log
         $log = new Log();
-        $log->setAction('ELIMINAR');
-        $log->setObjeto('Productos');
-        $log->setObjetoId($product->id);
-        $log->setDetail($product->toJson());
-        $log->setIp('2222');
-        $log->setUserId(auth()->user()->id);
+        $log->action = 'ELIMINAR';
+        $log->objeto = 'Productos';
+        $log->objeto_id = $product->id;
+        $log->detail = $product->toJson();
+        $log->ip = '2222';
+        $log->user_id = auth()->user()->id;
         $log->save();
 
         // Eliminación del producto

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -8,6 +8,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * @property int|mixed $user_id
+ */
 class Customer extends Model
 {
     use SoftDeletes;


### PR DESCRIPTION
Refactoriza el acceso a las propiedades de los modelos Customer y Log para usar directamente la notación de flecha (->) en lugar de los métodos `set`. Esto simplifica el código y mejora la legibilidad, al tiempo que se adhiere a las convenciones de acceso a propiedades en PHP.

Esta modificación evita la necesidad de mantener métodos `set` redundantes y facilita la evolución de los modelos.

FIXES #17