### PR TITLE
Agregar campo "imagen del producto" en el formulario de registro de productos

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -15,6 +15,7 @@ class Product extends Model
     protected $fillable = [
         'name',
         'description',
+        'image_url',
         'deleted_at'
     ];
 

--- a/database/migrations/2025_08_30_124447_add_image_url_to_products_table.php
+++ b/database/migrations/2025_08_30_124447_add_image_url_to_products_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->string('image_url', 2048)->nullable()->after('description');
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('image_url');
+        });
+    }
+};

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -18,7 +18,8 @@
                     </div>
                 @endif
 
-                <form action="{{ route('products.store') }}" id="form_product" method="POST">
+                <form action="{{ route('products.store') }}" id="form_product" method="POST" enctype="multipart/form-data"
+                >
                     @csrf
 
                     <div class="mb-3">
@@ -29,6 +30,11 @@
                     <div class="mb-3">
                         <label for="description" class="form-label">Descripción del Producto:</label>
                         <textarea id="description" name="description" class="form-control">{{ old('description') }}</textarea>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="image" class="form-label">Imagen del Producto:</label>
+                        <input type="file" id="image" name="image" class="form-control" accept="image/*">
                     </div>
 
                     <div class="mb-3">
@@ -52,10 +58,16 @@
         $(document).ready(function() {
             $('#saved').on('click', function(evento) {
                 evento.preventDefault();
+
+                const form = document.getElementById('form_product');
+                const formData = new FormData(form);
+
                 $.ajax({
                     url: $('#form_product').attr('action'),
                     method: $('#form_product').attr('method'),
-                    data: $('#form_product').serialize(),
+                    data: formData,
+                    processData: false,   // Importante para FormData
+                    contentType: false,   // Importante para FormData
                     success: function(response) {
                         if(response.status === 'success'){
                             alert('Registro exitoso');

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -17,7 +17,7 @@
                     </div>
                 @endif
                 {{-- Formulario --}}
-                <form action="{{ route('products.update', $product) }}" id="form_product" method="POST">
+                <form action="{{ route('products.update', $product) }}" id="form_product" method="POST" enctype="multipart/form-data">
                     @csrf
                     @method('PUT')
                     <div class="mb-3">
@@ -27,8 +27,13 @@
                     <div class="mb-3">
                         <label for="description" class="form-label">Descripción del Producto:</label>
                         <textarea name="description" class="form-control" rows="3">{{ old('description', $product->description) }}</textarea>
-
                     </div>
+
+                    <div class="mb-3">
+                        <label for="image" class="form-label">Imagen del Producto:</label>
+                        <input type="file" id="image" name="image" class="form-control" accept="image/*">
+                    </div>
+
                     <div class="mb-3">
                         @include('inc.companies')
                     </div>
@@ -49,10 +54,16 @@
         $(document).ready(function() {
             $('#update').on('click', function(evento) {
                 evento.preventDefault();
+
+                const form = document.getElementById('form_product');
+                const formData = new FormData(form);
+
                 $.ajax({
                     url: $('#form_product').attr('action'),
                     method: $('#form_product').attr('method'),
-                    data: $('#form_product').serialize(),
+                    data: formData,
+                    processData: false,   // Importante para FormData
+                    contentType: false,   // Importante para FormData
                     success: function(response) {
                         if(response.status === 'success'){
                             alert(response.message);

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -30,6 +30,7 @@
                         <tr>
                             <th>Nombre</th>
                             <th>Descripción</th>
+                            <th>Imagen del Producto</th>
                             <th class="text-center" style="width: 180px;">Acción</th >
                         </tr>
                     </thead>
@@ -38,6 +39,14 @@
                         <tr id="{!! $product->getId() !!}">
                             <td>{{ $product->getName() }}</td>
                             <td> {{ $product->getDescription() }}</td>
+                            <td>
+                                @php
+                                    $src = $product->image_url ? '/storage/images/' . $product->image_url : 'https://via.placeholder.com/64x64?text=No+Img';
+                                @endphp
+                                <img src="{{ $src }}" alt="{{ $product->name }}" style="width:64px;height:64px;object-fit:cover;border-radius:6px;">
+                            </td>
+
+
                             <td class="text-center">
                                 <a href="{{ route('products.edit', $product) }}" class="btn btn-sm btn-primary" title="Editar">
                                     <i class="fas fa-edit"></i>
@@ -65,7 +74,7 @@
                 let id = $(this).attr('data-id') // esta y la de abajohacen lo mismo
                 let url = $(this).data('url')
 
-                if(confirm('Estas seguro')) {
+                if(confirm('Estás seguro')) {
                     $.ajax({
                         url: url,
                         method: 'DELETE',

--- a/resources/views/products/view_products.blade.php
+++ b/resources/views/products/view_products.blade.php
@@ -14,6 +14,7 @@
                     <th>ID</th>
                     <th>Nombre</th>
                     <th>Descripción</th>
+                    <th>Imagen del Producto</th>
                 </tr>
             </thead>
             <tbody class="products"></tbody>
@@ -33,10 +34,15 @@
                     let products = response.data
                     let $tr = '';
                     for (const product of products) {
+                        let imageSrc = product.image_url ? '/storage/images/' + product.image_url : 'https://via.placeholder.com/64x64?text=No+Img';
+
                         $tr += '<tr>';
                         $tr += '<td>'+product.id+'</td>';
                         $tr += '<td>'+product.name+'</td>';
                         $tr += '<td>'+product.description+'</td>';
+                        $tr += '<td>';
+                        $tr += '<img src="' + imageSrc + '" alt="' + product.name + '" style="width:64px;height:64px;object-fit:cover;border-radius:6px;">';
+                        $tr += '</td>';
                         $tr += '</tr>';
                     }
                     $('.products').append($tr)

--- a/storage/app/private/.gitignore
+++ b/storage/app/private/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Permite la subida, actualización y eliminación de imágenes asociadas a los productos.

-   Agrega un campo `image_url` a la tabla y modelo de productos para almacenar la referencia a la imagen.
-   Implementa la lógica para guardar las imágenes en el sistema de archivos `storage/app/public/images`.
-   Implementa la lógica para eliminar las imágenes antiguas al actualizar un producto.
-   Muestra las imágenes en las vistas `index` y `view_products`.
-   Actualiza los formularios de creación y edición para permitir la subida de imágenes.

Closes #22
