### PR TITLE
28 [FEATURE]: Añadir columna `image_url` a la tabla `companies`. Modulo Empresa

### DIFF
--- a/database/migrations/2025_09_11_084114_add_image_url_to_companies_table.php
+++ b/database/migrations/2025_09_11_084114_add_image_url_to_companies_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->string('image_url', 2048)->nullable()->after('description');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropColumn('image_url');
+        });
+    }
+};


### PR DESCRIPTION
Se crea la migración `add_image_url_to_companies_table` que introduce la columna `image_url` (string, nullable) en la tabla `companies`.

Closes #28
