### PR TITLE
40 [FEATURE] Añadir API CRUD de Empresa en Laravel.

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -132,16 +132,8 @@ class CompanyController extends Controller
      */
     public function listCompanies(): JsonResponse
     {
-        $compania = Company::all();
-        $companies = [];
-        foreach ($compania as $company) {
-            $companies[] = [
-                'id' => $company->id,
-                'name' => $company->name,
-                'description' => $company->description,
-                'url_detail' => route('companies.show', $company->id),
-            ];
-        }
+        $companies = Company::all();
+
         return response()->json([
             'status' => 'success',
             'data' => $companies,

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\ProductController;
 use Illuminate\Support\Facades\Route;
 
@@ -12,10 +13,20 @@ Route::get('/test', function () {
 // Rutas para el controlador de productos
 Route::prefix('products')
     ->name('products.')
-    ->group(function () { 
-        Route::get('/', [ProductController::class, 'listProducts'])->name('lists');  // Listar 
+    ->group(function () {
+        Route::get('/', [ProductController::class, 'listProducts'])->name('lists');  // Listar
         Route::post('/save', [ProductController::class, 'store'])->name('store'); // Guardar nuevo
         Route::put('/{id}/update', [ProductController::class, 'update'])->name('update');     // Actualizar
         Route::delete('/{id}/delete', [ProductController::class, 'destroy'])->name('destroy'); // Eliminar
-        Route::get('/view', [ProductController::class, 'viewProducts'])->name('view');  // Listar
+
 });
+
+Route::prefix('companies')
+    ->name('companies.')
+    ->group(function () {
+        Route::get('/', [CompanyController::class, 'listCompanies'])->name('lists');  // Listar
+        Route::post('/save', [CompanyController::class, 'store'])->name('store'); // Guardar nuevo
+        Route::put('/{id}/update', [CompanyController::class, 'update'])->name('update');     // Actualizar
+        Route::delete('/{id}/delete', [CompanyController::class, 'destroy'])->name('destroy'); // Eliminar
+         // Listar
+    });


### PR DESCRIPTION
Crear un conjunto de endpoints RESTful en routes/api.php para gestionar la entidad Empresa.
La API deberá exponer operaciones de Lista, Consulta, Creación, Actualización y Eliminación, usando controladores de recurso, Form Request para validación y API Resources para formatear la salida.

Objetivos
Exponer una API REST para Empresas, CRUD completo, filtros, ordenación y paginación. Autenticada y con validación consistente.

Criterios de aceptación
GET /api/empresas devuelve un listado paginado de empresas

POST /api/empresas crea una nueva empresa validando name y description

PUT /api/empresas/{id} actualiza los campos permitidos de una empresa existente

DELETE /api/empresas/{id} elimina de forma permanente la empresa indicada.

Closes: #40
